### PR TITLE
Add rust-analyzer to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,7 @@
             cargo-audit
             rustfmt
             clippy
+            rust-analyzer
 
             # For `alpm` libs
             pkg-config


### PR DESCRIPTION
Very simple but allows for developers using Nix and a terminal-based editor to utilise proper LSP