### PR TITLE
Fixed up indentation on packages to review prompt

### DIFF
--- a/src/interact/theme.rs
+++ b/src/interact/theme.rs
@@ -149,7 +149,7 @@ impl Theme for AmeTheme {
         prompt: &str,
         selections: &[&str],
     ) -> std::fmt::Result {
-        write!(f, "{}: ", prompt.bold())?;
+        write!(f, "  {}: ", prompt.bold())?;
         if selections.is_empty() {
             write!(f, "{}", "No selections".italic())?;
         } else {

--- a/src/operations/aur_install/aur_review.rs
+++ b/src/operations/aur_install/aur_review.rs
@@ -41,7 +41,6 @@ impl AurReview {
     }
 
     async fn review_single_package(&self, pkg: &str) -> AppResult<()> {
-        newline!();
         tracing::info!("Reviewing {pkg}");
         let mut files_iter = fs::read_dir(get_cache_dir().join(pkg)).await?;
         let mut files = Vec::new();

--- a/src/operations/aur_install/aur_review.rs
+++ b/src/operations/aur_install/aur_review.rs
@@ -8,7 +8,7 @@ use crate::{
         structs::Options,
         utils::get_cache_dir,
     },
-    multi_select, newline, prompt, select_opt,
+    multi_select, prompt, select_opt,
 };
 
 use super::{repo_dependency_installation::RepoDependencyInstallation, BuildContext};


### PR DESCRIPTION
I think this is the only remaining formatting issue

I believe that Amethyst v4.0.0 is almost ready to ship, par a few specific use-case issues, such as @SomethingGeneric's issue with `obs-v4l2sink-git`, where we should attempt to introduce fuzzy matching if the expected package filename isn't found.