### PR TITLE
Remove packagefile match check to fix Git packages

### DIFF
--- a/src/internal/alpm.rs
+++ b/src/internal/alpm.rs
@@ -1,9 +1,10 @@
 use std::{
     fmt::{Display, Formatter},
     path::Path,
+    path::PathBuf,
 };
 
-use alpm::Alpm;
+use alpm::SigLevel;
 use alpm_utils::alpm_with_conf;
 use pacmanconf::Config;
 
@@ -34,12 +35,52 @@ impl From<pacmanconf::Error> for Error {
     }
 }
 
-#[tracing::instrument(level = "trace")]
-pub fn get_handler() -> Result<Alpm, Error> {
-    let config = Config::from_file(Path::new("/etc/pacman.conf"))?;
-    let alpm = alpm_with_conf(&config)?;
+pub enum PackageFrom {
+    #[allow(dead_code)]
+    LocalDb(String),
 
-    tracing::debug!("Initialized alpm handler");
+    #[allow(dead_code)]
+    SyncDb(String),
 
-    Ok(alpm)
+    File(PathBuf),
+}
+
+pub struct Alpm(alpm::Alpm);
+
+impl Alpm {
+    #[tracing::instrument(level = "trace")]
+    pub fn new() -> Result<Self, Error> {
+        let config = Config::from_file(Path::new("/etc/pacman.conf"))?;
+        let alpm = alpm_with_conf(&config)?;
+        tracing::debug!("Initialized alpm handler");
+        Ok(Self(alpm))
+    }
+
+    pub fn load(&self, pkg: PackageFrom) -> Result<alpm::Pkg, Error> {
+        match pkg {
+            PackageFrom::LocalDb(name) => {
+                let db = self.0.localdb();
+                let package = db.pkg(name)?;
+                Ok(*package)
+            }
+            PackageFrom::SyncDb(name) => {
+                let package = self
+                    .0
+                    .syncdbs()
+                    .find_satisfier(name)
+                    .ok_or(Error::Alpm(alpm::Error::PkgNotFound))?;
+                Ok(*package)
+            }
+            PackageFrom::File(path) => {
+                let package = self
+                    .0
+                    .pkg_load(path.to_str().unwrap(), true, SigLevel::NONE)?;
+                Ok(*package)
+            }
+        }
+    }
+
+    pub fn handler(&self) -> &alpm::Alpm {
+        &self.0
+    }
 }

--- a/src/internal/alpm.rs
+++ b/src/internal/alpm.rs
@@ -1,4 +1,7 @@
-use std::path::Path;
+use std::{
+    fmt::{Display, Formatter},
+    path::Path,
+};
 
 use alpm::Alpm;
 use alpm_utils::alpm_with_conf;
@@ -8,6 +11,15 @@ use pacmanconf::Config;
 pub enum Error {
     Alpm(alpm::Error),
     Pacmanconf(pacmanconf::Error),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Alpm(e) => Display::fmt(e, f),
+            Self::Pacmanconf(e) => Display::fmt(e, f),
+        }
+    }
 }
 
 impl From<alpm::Error> for Error {

--- a/src/internal/error.rs
+++ b/src/internal/error.rs
@@ -21,6 +21,7 @@ pub enum AppError {
     MakePkg(String),
     MinusError(minus::MinusError),
     FmtError(std::fmt::Error),
+    AlpmError(crate::internal::alpm::Error),
 }
 
 impl Display for AppError {
@@ -36,9 +37,10 @@ impl Display for AppError {
             AppError::MissingDependencies(deps) => {
                 write!(f, "Missing dependencies {}", deps.join(", "))
             }
-            AppError::MakePkg(msg) => write!(f, "Failed to ru makepkg {msg}"),
+            AppError::MakePkg(msg) => write!(f, "Failed to run makepkg {msg}"),
             AppError::MinusError(e) => Display::fmt(e, f),
             AppError::FmtError(e) => Display::fmt(e, f),
+            AppError::AlpmError(e) => Display::fmt(e, f),
         }
     }
 }
@@ -78,6 +80,12 @@ impl From<minus::MinusError> for AppError {
 impl From<std::fmt::Error> for AppError {
     fn from(e: std::fmt::Error) -> Self {
         Self::FmtError(e)
+    }
+}
+
+impl From<crate::internal::alpm::Error> for AppError {
+    fn from(e: crate::internal::alpm::Error) -> Self {
+        Self::AlpmError(e)
     }
 }
 

--- a/src/operations/aur_install/common.rs
+++ b/src/operations/aur_install/common.rs
@@ -207,10 +207,10 @@ async fn build_package(
     let mut pkgs_produced: HashMap<String, PathBuf> = HashMap::new();
     let alpm = Alpm::new()?;
 
-    for ar in archives {
-        let pkg = alpm.load(PackageFrom::File(ar.clone()))?;
+    for archive in archives {
+        let pkg = alpm.load(PackageFrom::File(archive.clone()))?;
         let name = pkg.name().to_owned();
-        pkgs_produced.insert(name, ar);
+        pkgs_produced.insert(name, archive);
     }
     tracing::debug!("Produced packages: {pkgs_produced:#?}");
 

--- a/src/operations/aur_install/common.rs
+++ b/src/operations/aur_install/common.rs
@@ -206,12 +206,13 @@ async fn build_package(
 
     let mut pkgs_produced: HashMap<String, PathBuf> = HashMap::new();
     let alpm = crate::internal::alpm::get_handler()?;
+
     for ar in archives {
         let pkg = alpm
             .pkg_load(ar.to_str().unwrap(), true, SigLevel::NONE)
             .map_err(|e| AppError::Other(e.to_string()))?;
         let name = pkg.name().to_owned();
-        pkgs_produced.insert(name, ar.clone());
+        pkgs_produced.insert(name, ar);
     }
     tracing::debug!("Produced packages: {pkgs_produced:#?}");
 
@@ -220,7 +221,7 @@ async fn build_package(
         .ok_or_else(|| {
             AppError::Other(format!(
                 "Could not find package {} in produced packages",
-                ctx.package.metadata.name
+                pkg_name.clone()
             ))
         })?;
 

--- a/src/operations/aur_install/common.rs
+++ b/src/operations/aur_install/common.rs
@@ -198,7 +198,7 @@ async fn build_package(
 
     let packages = MakePkgBuilder::package_list(build_path).await?;
     tracing::debug!("Archives: {packages:?}");
-    
+
     pb.finish_with_message(format!("{}: {}", pkg_name.clone().bold(), "Built!".green()));
     ctx.step = BuildStep::Install(PackageArchives(packages));
 

--- a/src/operations/aur_install/common.rs
+++ b/src/operations/aur_install/common.rs
@@ -196,23 +196,9 @@ async fn build_package(
         });
     }
 
-    let mut packages = MakePkgBuilder::package_list(build_path).await?;
-    let match_version = ctx
-        .package
-        .metadata
-        .version
-        .rsplit_once('_')
-        .map(|v| v.0)
-        .unwrap_or(&ctx.package.metadata.version);
-    let match_name = format!("{pkg_name}-{match_version}");
-    tracing::debug!("Match name {match_name}");
-    packages.retain(|name| {
-        name.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap()
-            .starts_with(&match_name)
-    });
+    let packages = MakePkgBuilder::package_list(build_path).await?;
     tracing::debug!("Archives: {packages:?}");
+    
     pb.finish_with_message(format!("{}: {}", pkg_name.clone().bold(), "Built!".green()));
     ctx.step = BuildStep::Install(PackageArchives(packages));
 

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -1,7 +1,6 @@
 use crate::crash;
 use crate::internal::commands::ShellCommand;
 
-use crate::internal::config;
 use crate::internal::error::SilentUnwrap;
 use crate::internal::exit_code::AppExitCode;
 

--- a/src/operations/search.rs
+++ b/src/operations/search.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str::FromStr;
 
-use crate::internal::alpm::get_handler;
+use crate::internal::alpm::Alpm;
 use crate::internal::error::SilentUnwrap;
 use crate::internal::exit_code::AppExitCode;
 use crate::internal::rpc::rpcsearch;
@@ -131,7 +131,9 @@ pub async fn aur_search(
     by_field: Option<SearchBy>,
     options: Options,
 ) -> Vec<PackageSearchResult> {
-    let alpm = get_handler().unwrap();
+    let alpm = Alpm::new().unwrap();
+    let alpm = alpm.handler();
+
     let local = alpm.localdb();
     let packages = rpcsearch(query.to_string(), by_field.map(SearchBy::into))
         .await
@@ -167,7 +169,9 @@ pub async fn aur_search(
 
 #[tracing::instrument(level = "trace")]
 pub async fn repo_search(query: &str, options: Options) -> Vec<PackageSearchResult> {
-    let alpm = get_handler().unwrap();
+    let alpm = Alpm::new().unwrap();
+    let alpm = alpm.handler();
+
     let local = alpm.localdb();
     let dbs = alpm.syncdbs();
 


### PR DESCRIPTION
This check ends up breaking every `-git` package

If a `PKGBUILD` were to potentially install malware in the form of an extra `.pkg.tar.zst` onto a user's computer, they will be able to see by reviewing the `PKGBUILD`

Any potential input welcome, of course