### PR TITLE
Remove redundant config

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,17 @@
+# Config Keys
+
+## [base]
+| Key | Description | Default |
+| --- | --- | --- |
+| `pacdiff_warn` | Whether to warn the user about `vimdiff` for `pacdiff` | `true` |
+
+## [extra]
+| Key | Description | Default |
+| --- | --- | --- |
+| `uwu` | Makes Amethyst's output... "cuter" | `false` |
+| `uwu_debug` | Makes debug and traces `uwu`ed. Please never send us debug logs with this enabled. | `false` |
+
+## [bin]
+| Key | Description | Default |
+| --- | --- | --- |
+| `sudo` | The path to use for `sudo` (or any `sudo`-likes) | `'sudo'` |

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -10,22 +10,19 @@ use super::utils::get_config_dir;
 #[derive(Default, Debug, Deserialize, Serialize)]
 pub struct Config {
     pub base: ConfigBase,
-    pub extra: ConfigExtra,
+    pub extra: Option<ConfigExtra>,
     pub bin: ConfigBin,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigBase {
     pub pacdiff_warn: bool,
-    pub highlight_optdepends: bool,
-    pub powerpill: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct ConfigExtra {
     pub uwu: Option<bool>,
     pub uwu_debug: Option<bool>,
-    pub review_user_shell: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -35,21 +32,7 @@ pub struct ConfigBin {
 
 impl Default for ConfigBase {
     fn default() -> Self {
-        Self {
-            pacdiff_warn: true,
-            highlight_optdepends: true,
-            powerpill: false,
-        }
-    }
-}
-
-impl Default for ConfigExtra {
-    fn default() -> Self {
-        Self {
-            uwu: None,
-            uwu_debug: None,
-            review_user_shell: false,
-        }
+        Self { pacdiff_warn: true }
     }
 }
 

--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -49,12 +49,6 @@ pub async fn detect() {
         if choice {
             let config = Config::get();
             if config.base.pacdiff_warn {
-                ShellCommand::pacdiff()
-                    .elevated()
-                    .wait()
-                    .await
-                    .silent_unwrap(AppExitCode::PacmanError);
-            } else {
                 tracing::warn!("Pacdiff uses vimdiff by default to edit files for merging. You can focus panes by mousing over them and pressing left click, and scroll up and down using your mouse's scroll wheel (or the arrow keys). To exit vimdiff, press the following key combination: ESC, :qa!, ENTER");
                 tracing::warn!("You can surpress this warning in the future by setting `pacdiff_warn` to \"false\" in ~/.config/ame/config.toml");
 
@@ -65,6 +59,12 @@ pub async fn detect() {
                         .await
                         .silent_unwrap(AppExitCode::PacmanError);
                 }
+            } else {
+                ShellCommand::pacdiff()
+                    .elevated()
+                    .wait()
+                    .await
+                    .silent_unwrap(AppExitCode::PacmanError);
             }
         }
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -39,7 +39,15 @@ macro_rules! uwu {
 
 pub fn uwu_enabled() -> bool {
     let config = config::Config::get();
-    config.extra.uwu.unwrap_or(false)
+    if let Some(uwu) = &config.extra {
+        if let Some(uwu) = uwu.uwu {
+            uwu
+        } else {
+            false
+        }
+    } else {
+        false
+    }
 }
 
 /// Checks if we're running in a tty. If we do we can assume that

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use builder::pacman::{PacmanColor, PacmanQueryBuilder};
 use clap::Parser;
 
 use internal::commands::ShellCommand;
+use internal::detect;
 use internal::error::SilentUnwrap;
 
 use crate::args::{InstallArgs, Operation, QueryArgs, RemoveArgs};
@@ -68,7 +69,7 @@ async fn main() {
             operations::clean(options).await;
         }
         Operation::GenComp(gen_args) => cmd_gencomp(&gen_args),
-        Operation::Diff => todo!(),
+        Operation::Diff => detect().await,
     }
 }
 


### PR DESCRIPTION
- Removes redundant config keys
- Fixed bug with `pacdiff_warn` config key logic being flipped
- Adds documentation for config keys