### PR TITLE
Refactor `sort()` to use Alpm as opposed to calling `pacman -Ss`

### DIFF
--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -10,6 +10,7 @@ use crate::prompt;
 use super::prompt_sudo_single;
 
 /// Searches the filesystem for .pacnew files and helps the user deal with them.
+#[tracing::instrument(level = "trace")]
 pub async fn detect() {
     prompt_sudo_single().await.expect("Sudo prompt failed");
     let pb = get_logger().new_progress_spinner();

--- a/src/internal/rpc.rs
+++ b/src/internal/rpc.rs
@@ -9,6 +9,21 @@ pub async fn rpcinfo(pkg: &str) -> AppResult<Option<PackageInfo>> {
     Ok(packages.into_iter().next())
 }
 
+pub async fn rpcinfo_many(pkgs: &[String]) -> AppResult<Vec<PackageInfo>> {
+    let mut futures = vec![];
+    for pkg in pkgs {
+        futures.push(aur_rpc::info(vec![pkg]));
+    }
+
+    let mut results = vec![];
+    for future in futures {
+        let mut result = future.await?;
+        results.append(&mut result);
+    }
+
+    Ok(results)
+}
+
 pub async fn rpcsearch(
     query: String,
     by_field: Option<SearchField>,


### PR DESCRIPTION
This will likely be much, much faster. We should generally make sure we call `pacman` itself as little as possible