### PR TITLE
commands: remove Option from the sudo key

### DIFF
--- a/src/internal/commands.rs
+++ b/src/internal/commands.rs
@@ -52,12 +52,7 @@ impl ShellCommand {
     }
 
     pub fn sudo() -> Self {
-        Self::new(
-            Config::read()
-                .bin
-                .sudo
-                .unwrap_or_else(|| "sudo".to_string()),
-        )
+        Self::new(Config::read().bin.sudo)
     }
 
     pub fn rm() -> Self {
@@ -152,12 +147,7 @@ impl ShellCommand {
             (Stdio::inherit(), Stdio::inherit())
         };
         let mut command = if self.elevated {
-            let mut cmd = Command::new(
-                Config::read()
-                    .bin
-                    .sudo
-                    .unwrap_or_else(|| "sudo".to_string()),
-            );
+            let mut cmd = Command::new(Config::read().bin.sudo);
             cmd.arg(self.command);
 
             cmd

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -27,7 +27,7 @@ pub struct ConfigExtra {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigBin {
-    pub sudo: Option<String>,
+    pub sudo: String,
 }
 
 impl Default for ConfigBase {
@@ -39,7 +39,7 @@ impl Default for ConfigBase {
 impl Default for ConfigBin {
     fn default() -> Self {
         Self {
-            sudo: Some("sudo".to_string()),
+            sudo: "sudo".to_string(),
         }
     }
 }


### PR DESCRIPTION
we dont need Option as the sudo key is assumed to always be there and if its not in the config file, it will fall back to the default value