### PR TITLE
Implement Builders for Shell Commands without a Builder

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -17,6 +17,10 @@ pub struct Args {
     #[clap(long = "noconfirm", global = true)]
     pub no_confirm: bool,
 
+    /// Make some commands have less output
+    #[clap(long, short, global = true)]
+    pub quiet: bool,
+
     /// Loops sudo in the background to ensure it doesn't time out during long builds
     #[clap(long = "sudoloop", global = true)]
     pub sudoloop: bool,

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -3,3 +3,4 @@ pub mod makepkg;
 pub mod pacdiff;
 pub mod pacman;
 pub mod pager;
+pub mod rm;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,4 +1,5 @@
 pub mod git;
 pub mod makepkg;
+pub mod pacdiff;
 pub mod pacman;
 pub mod pager;

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,5 +1,6 @@
 pub mod git;
 pub mod makepkg;
+pub mod paccache;
 pub mod pacdiff;
 pub mod pacman;
 pub mod pager;

--- a/src/builder/paccache.rs
+++ b/src/builder/paccache.rs
@@ -1,0 +1,45 @@
+use crate::internal::{commands::ShellCommand, error::AppResult};
+
+#[derive(Debug, Default)]
+pub struct PaccacheBuilder {
+    keep: i32,
+    keep_ins: bool,
+    quiet: bool,
+}
+
+impl PaccacheBuilder {
+    pub fn keep(mut self, keep: i32) -> Self {
+        self.keep = keep;
+
+        self
+    }
+
+    pub fn keep_ins(mut self, keep_ins: bool) -> Self {
+        self.keep_ins = keep_ins;
+
+        self
+    }
+
+    pub fn quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
+
+        self
+    }
+
+    pub async fn remove(self) -> AppResult<()> {
+        let mut command = ShellCommand::paccache().elevated();
+
+        if self.quiet {
+            command = command.arg("-q");
+        }
+
+        if self.keep_ins {
+            command = command.arg("-u")
+        }
+
+        command
+            .args(&["-r", &format!("-k{}", self.keep.to_string())])
+            .wait_success()
+            .await
+    }
+}

--- a/src/builder/paccache.rs
+++ b/src/builder/paccache.rs
@@ -3,25 +3,25 @@ use crate::internal::{commands::ShellCommand, error::AppResult};
 #[derive(Debug, Default)]
 pub struct PaccacheBuilder {
     keep: i32,
-    keep_ins: bool,
-    quiet: bool,
+    keep_ins_pkgs: bool,
+    quiet_output: bool,
 }
 
 impl PaccacheBuilder {
-    pub fn keep(mut self, keep: i32) -> Self {
+    pub fn set_keep(mut self, keep: i32) -> Self {
         self.keep = keep;
 
         self
     }
 
-    pub fn keep_ins(mut self, keep_ins: bool) -> Self {
-        self.keep_ins = keep_ins;
+    pub fn keep_ins_pkgs(mut self, keep_ins_pkgs: bool) -> Self {
+        self.keep_ins_pkgs = keep_ins_pkgs;
 
         self
     }
 
-    pub fn quiet(mut self, quiet: bool) -> Self {
-        self.quiet = quiet;
+    pub fn quiet_output(mut self, quiet_output: bool) -> Self {
+        self.quiet_output = quiet_output;
 
         self
     }
@@ -30,11 +30,11 @@ impl PaccacheBuilder {
     pub async fn remove(self) -> AppResult<()> {
         let mut command = ShellCommand::paccache().elevated();
 
-        if self.quiet {
+        if self.quiet_output {
             command = command.arg("-q");
         }
 
-        if self.keep_ins {
+        if self.keep_ins_pkgs {
             command = command.arg("-u")
         }
 

--- a/src/builder/paccache.rs
+++ b/src/builder/paccache.rs
@@ -26,6 +26,7 @@ impl PaccacheBuilder {
         self
     }
 
+    #[tracing::instrument(level = "trace")]
     pub async fn remove(self) -> AppResult<()> {
         let mut command = ShellCommand::paccache().elevated();
 

--- a/src/builder/pacdiff.rs
+++ b/src/builder/pacdiff.rs
@@ -1,0 +1,27 @@
+use crate::internal::{
+    commands::{ShellCommand, StringOutput},
+    error::{AppError, AppResult, SilentUnwrap},
+    exit_code::AppExitCode,
+};
+
+#[derive(Debug, Default)]
+pub struct PacdiffBuilder {}
+
+impl PacdiffBuilder {
+    pub async fn list() -> AppResult<StringOutput> {
+        let result = ShellCommand::pacdiff()
+            .args(&["-o", "-f"])
+            .elevated()
+            .wait_with_output()
+            .await?;
+        if result.status.success() {
+            Ok(result)
+        } else {
+            Err(AppError::Other(result.stderr))
+        }
+    }
+
+    pub async fn pacdiff() -> AppResult<()> {
+        ShellCommand::pacdiff().elevated().wait_success().await
+    }
+}

--- a/src/builder/pacdiff.rs
+++ b/src/builder/pacdiff.rs
@@ -7,6 +7,7 @@ use crate::internal::{
 pub struct PacdiffBuilder {}
 
 impl PacdiffBuilder {
+    #[tracing::instrument(level = "trace")]
     pub async fn list() -> AppResult<StringOutput> {
         let result = ShellCommand::pacdiff()
             .args(&["-o", "-f"])
@@ -20,6 +21,7 @@ impl PacdiffBuilder {
         }
     }
 
+    #[tracing::instrument(level = "trace")]
     pub async fn pacdiff() -> AppResult<()> {
         ShellCommand::pacdiff().elevated().wait_success().await
     }

--- a/src/builder/pacdiff.rs
+++ b/src/builder/pacdiff.rs
@@ -1,7 +1,6 @@
 use crate::internal::{
     commands::{ShellCommand, StringOutput},
-    error::{AppError, AppResult, SilentUnwrap},
-    exit_code::AppExitCode,
+    error::{AppError, AppResult},
 };
 
 #[derive(Debug, Default)]

--- a/src/builder/pacman.rs
+++ b/src/builder/pacman.rs
@@ -254,6 +254,30 @@ impl PacmanSearchBuilder {
 }
 
 #[derive(Default, Debug, Clone)]
+pub struct PacmanUpgradeBuilder {
+    no_confirm: bool,
+}
+
+impl PacmanUpgradeBuilder {
+    pub fn no_confirm(mut self, no_confirm: bool) -> Self {
+        self.no_confirm = no_confirm;
+
+        self
+    }
+
+    #[tracing::instrument(level = "trace")]
+    pub async fn upgrade(self) -> AppResult<()> {
+        let mut command = ShellCommand::pacman().elevated().arg("-Syu");
+
+        if self.no_confirm {
+            command = command.arg("--noconfirm")
+        }
+
+        command.wait_success().await
+    }
+}
+
+#[derive(Default, Debug, Clone)]
 pub struct PacmanUninstallBuilder {
     packages: Vec<String>,
     no_confirm: bool,

--- a/src/builder/rm.rs
+++ b/src/builder/rm.rs
@@ -1,0 +1,46 @@
+use std::path::{Path, PathBuf};
+
+use crate::internal::{commands::ShellCommand, error::AppResult};
+
+#[derive(Debug, Default)]
+pub struct RmBuilder {
+    recursive: bool,
+    force: bool,
+    directory: PathBuf,
+}
+
+impl RmBuilder {
+    pub fn recursive(mut self, recursive: bool) -> Self {
+        self.recursive = recursive;
+
+        self
+    }
+
+    pub fn force(mut self, force: bool) -> Self {
+        self.force = force;
+
+        self
+    }
+
+    pub fn directory<P: AsRef<Path>>(mut self, directory: P) -> Self {
+        self.directory = directory.as_ref().into();
+
+        self
+    }
+
+    pub async fn build(self) -> AppResult<()> {
+        let mut command = ShellCommand::rm().elevated();
+
+        if self.recursive {
+            command = command.arg("-r");
+        }
+
+        if self.force {
+            command = command.arg("-f");
+        }
+
+        command = command.arg(self.directory);
+
+        command.wait_success().await
+    }
+}

--- a/src/builder/rm.rs
+++ b/src/builder/rm.rs
@@ -28,6 +28,7 @@ impl RmBuilder {
         self
     }
 
+    #[tracing::instrument(level = "trace")]
     pub async fn build(self) -> AppResult<()> {
         let mut command = ShellCommand::rm().elevated();
 

--- a/src/internal/commands.rs
+++ b/src/internal/commands.rs
@@ -25,13 +25,7 @@ pub struct ShellCommand {
 
 impl ShellCommand {
     pub fn pacman() -> Self {
-        let pacman_cmd = Self::new("pacman");
-
-        if is_tty() {
-            pacman_cmd.arg("--color=always")
-        } else {
-            pacman_cmd
-        }
+        Self::new("pacman")
     }
 
     pub fn paccache() -> Self {

--- a/src/internal/commands.rs
+++ b/src/internal/commands.rs
@@ -34,6 +34,16 @@ impl ShellCommand {
         }
     }
 
+    pub fn paccache() -> Self {
+        let paccache_cmd = Self::new("paccache");
+
+        if is_tty() {
+            paccache_cmd
+        } else {
+            paccache_cmd.arg("--nocolor")
+        }
+    }
+
     pub fn pacdiff() -> Self {
         Self::new("pacdiff")
     }

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -17,6 +17,8 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigBase {
     pub pacdiff_warn: bool,
+    pub paccache_keep: i32,
+    pub paccache_keep_ins: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -32,7 +34,11 @@ pub struct ConfigBin {
 
 impl Default for ConfigBase {
     fn default() -> Self {
-        Self { pacdiff_warn: true }
+        Self {
+            pacdiff_warn: true,
+            paccache_keep: 0,
+            paccache_keep_ins: true,
+        }
     }
 }
 
@@ -59,7 +65,7 @@ impl Config {
         } else {
             let default_conf = Config::default();
             let toml_string = toml::ser::to_string_pretty(&default_conf).unwrap();
-            fs::write(config_path, format!("{}\n\n{}", "# See https://github.com/crystal-linux/amethyst/tree/main/docs for more information on config keys", toml_string)).unwrap();
+            fs::write(config_path, format!("{}\n\n{}", "# See https://github.com/crystal-linux/docs/blob/main/Amethyst/config.mdx for more information on config keys", toml_string)).unwrap();
             default_conf
         }
     }

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
 pub struct ConfigBase {
     pub pacdiff_warn: bool,
     pub paccache_keep: i32,
-    pub paccache_keep_ins: bool,
+    pub paccache_keep_ins_pkgs: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -37,7 +37,7 @@ impl Default for ConfigBase {
         Self {
             pacdiff_warn: true,
             paccache_keep: 0,
-            paccache_keep_ins: true,
+            paccache_keep_ins_pkgs: true,
         }
     }
 }

--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -1,10 +1,7 @@
 use crossterm::style::Stylize;
 
 use crate::builder::pacdiff::PacdiffBuilder;
-use crate::internal::commands::ShellCommand;
 use crate::internal::config::Config;
-use crate::internal::error::SilentUnwrap;
-use crate::internal::exit_code::AppExitCode;
 use crate::logging::get_logger;
 use crate::prompt;
 

--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -1,5 +1,6 @@
 use crossterm::style::Stylize;
 
+use crate::builder::pacdiff::PacdiffBuilder;
 use crate::internal::commands::ShellCommand;
 use crate::internal::config::Config;
 use crate::internal::error::SilentUnwrap;
@@ -19,12 +20,7 @@ pub async fn detect() {
     let mut pacnew = vec![];
 
     // Run `find` to find pacnew files and split by lines into a vec
-    let find = ShellCommand::pacdiff()
-        .args(&["-o", "-f"])
-        .elevated()
-        .wait_with_output()
-        .await
-        .silent_unwrap(AppExitCode::PacmanError);
+    let find = PacdiffBuilder::list().await.unwrap();
     let find_lines = find.stdout.split('\n');
     for line in find_lines {
         if !line.is_empty() {
@@ -54,18 +50,10 @@ pub async fn detect() {
                 tracing::warn!("You can surpress this warning in the future by setting `pacdiff_warn` to \"false\" in ~/.config/ame/config.toml");
 
                 if prompt!(default no, "Continue?") {
-                    ShellCommand::pacdiff()
-                        .elevated()
-                        .wait()
-                        .await
-                        .silent_unwrap(AppExitCode::PacmanError);
+                    PacdiffBuilder::pacdiff().await.unwrap();
                 }
             } else {
-                ShellCommand::pacdiff()
-                    .elevated()
-                    .wait()
-                    .await
-                    .silent_unwrap(AppExitCode::PacmanError);
+                PacdiffBuilder::pacdiff().await.unwrap();
             }
         }
     }

--- a/src/internal/structs.rs
+++ b/src/internal/structs.rs
@@ -19,6 +19,7 @@ impl Sorted {
 /// Options to be passed down to internal functions
 pub struct Options {
     pub noconfirm: bool,
+    pub quiet: bool,
     pub asdeps: bool,
     pub upgrade: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,9 +37,11 @@ async fn main() {
     init_logger(args.verbose.into());
 
     let noconfirm = args.no_confirm;
+    let quiet = args.quiet;
 
     let options = Options {
         noconfirm,
+        quiet,
         asdeps: false,
         upgrade: false,
     };

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -1,3 +1,4 @@
+use crate::builder::rm::RmBuilder;
 use crate::crash;
 use crate::internal::commands::ShellCommand;
 
@@ -73,12 +74,11 @@ pub async fn clean(options: Options) {
     let clear_ame_cache = prompt!(default no, "Clear Amethyst's internal PKGBUILD cache?");
     if clear_ame_cache {
         let cache_dir = get_cache_dir();
-        ShellCommand::rm()
-            .arg(cache_dir)
-            .arg("-r")
-            .arg("-f")
-            .elevated()
-            .wait_success()
+        RmBuilder::default()
+            .recursive(true)
+            .force(true)
+            .directory(cache_dir)
+            .build()
             .await
             .unwrap();
     }

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -91,9 +91,9 @@ pub async fn clean(options: Options) {
         // keeps 0 versions of the package in the cache by default
         // keeps installed packages in the cache by default
         let result = PaccacheBuilder::default()
-            .keep(conf.base.paccache_keep)
-            .keep_ins(conf.base.paccache_keep_ins)
-            .quiet(quiet)
+            .set_keep(conf.base.paccache_keep)
+            .keep_ins_pkgs(conf.base.paccache_keep_ins_pkgs)
+            .quiet_output(quiet)
             .remove()
             .await;
 

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -85,18 +85,6 @@ pub async fn clean(options: Options) {
 
     if clear_pacman_cache {
         let conf = Config::read();
-        let mut debug_str = "Clearing using paccache -r".to_string();
-
-        debug_str = format!("{} -k{}", debug_str, conf.base.paccache_keep);
-        if conf.base.paccache_keep_ins {
-            debug_str = format!("{} -u", debug_str);
-        }
-
-        if quiet {
-            debug_str = format!("{} -q", debug_str);
-        }
-
-        tracing::debug!(debug_str);
 
         // Clear pacman's cache
         // keeps 0 versions of the package in the cache by default

--- a/src/operations/uninstall.rs
+++ b/src/operations/uninstall.rs
@@ -2,30 +2,24 @@ use std::env;
 use std::path::Path;
 use tokio::fs;
 
-use crate::internal::commands::ShellCommand;
-use crate::internal::error::SilentUnwrap;
+use crate::builder::pacman::PacmanUninstallBuilder;
 use crate::internal::exit_code::AppExitCode;
-use crate::Options;
+use crate::{crash, Options};
 
 /// Uninstalls the given packages
 #[tracing::instrument(level = "trace")]
 pub async fn uninstall(packages: Vec<String>, options: Options) {
-    let mut pacman_args = vec!["-Rs"];
-    pacman_args.append(&mut packages.iter().map(|s| s.as_str()).collect());
-
-    if options.noconfirm {
-        pacman_args.push("--noconfirm");
-    }
     tracing::debug!("Uninstalling: {:?}", &packages);
 
-    ShellCommand::pacman()
-        .elevated()
-        .args(pacman_args)
-        .wait_success()
+    PacmanUninstallBuilder::default()
+        .recursive(true)
+        .no_confirm(options.noconfirm)
+        .packages(&packages)
+        .uninstall()
         .await
-        .silent_unwrap(AppExitCode::PacmanError);
-
-    tracing::debug!("Uninstalling packages: {:?} exited with code 0", &packages);
+        .unwrap_or_else(|_| {
+            crash!(AppExitCode::PacmanError, "Failed to remove packages");
+        });
 
     for package in packages {
         if Path::new(&format!(

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -1,6 +1,5 @@
 use crate::args::UpgradeArgs;
-use crate::builder::pacman::{PacmanColor, PacmanQueryBuilder};
-use crate::internal::commands::ShellCommand;
+use crate::builder::pacman::{PacmanColor, PacmanQueryBuilder, PacmanUpgradeBuilder};
 use crate::internal::detect;
 use crate::internal::error::SilentUnwrap;
 use crate::internal::exit_code::AppExitCode;
@@ -27,31 +26,22 @@ pub async fn upgrade(args: UpgradeArgs, options: Options) {
 async fn upgrade_repo(options: Options) {
     let noconfirm = options.noconfirm;
 
-    let mut pacman_args = vec!["-Syu"];
-    if noconfirm {
-        pacman_args.push("--noconfirm");
-    }
-
     tracing::debug!("Upgrading repo packages");
 
-    let pacman_result = ShellCommand::pacman()
-        .elevated()
-        .args(pacman_args)
-        .wait()
+    PacmanUpgradeBuilder::default()
+        .no_confirm(noconfirm)
+        .upgrade()
         .await
-        .silent_unwrap(AppExitCode::PacmanError);
-
-    if pacman_result.success() {
-        tracing::info!("Successfully upgraded repo packages");
-    } else {
-        let continue_upgrading = prompt!(default no,
-            "Failed to upgrade repo packages, continue to upgrading AUR packages?",
-        );
-        if !continue_upgrading {
-            tracing::info!("Exiting");
-            std::process::exit(AppExitCode::PacmanError as i32);
-        }
-    }
+        .unwrap_or_else(|_| {
+            let continue_upgrading = prompt!(default no,
+                "Failed to upgrade repo packages, continue to upgrading AUR packages?",
+            );
+            if !continue_upgrading {
+                tracing::info!("Exiting");
+                std::process::exit(AppExitCode::PacmanError as i32);
+            }
+        });
+    tracing::info!("Successfully upgraded repo packages");
 }
 
 #[tracing::instrument(level = "trace")]

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -28,20 +28,22 @@ async fn upgrade_repo(options: Options) {
 
     tracing::debug!("Upgrading repo packages");
 
-    PacmanUpgradeBuilder::default()
+    let result = PacmanUpgradeBuilder::default()
         .no_confirm(noconfirm)
         .upgrade()
-        .await
-        .unwrap_or_else(|_| {
-            let continue_upgrading = prompt!(default no,
-                "Failed to upgrade repo packages, continue to upgrading AUR packages?",
-            );
-            if !continue_upgrading {
-                tracing::info!("Exiting");
-                std::process::exit(AppExitCode::PacmanError as i32);
-            }
-        });
-    tracing::info!("Successfully upgraded repo packages");
+        .await;
+
+    if let Err(_) = result {
+        let continue_upgrading = prompt!(default no,
+            "Failed to upgrade repo packages, continue to upgrading AUR packages?",
+        );
+        if !continue_upgrading {
+            tracing::info!("Exiting");
+            std::process::exit(AppExitCode::PacmanError as i32);
+        }
+    } else {
+        tracing::info!("Successfully upgraded repo packages");
+    }
 }
 
 #[tracing::instrument(level = "trace")]


### PR DESCRIPTION
Currently, for some shell commands Amethyst executes, it uses `ShellCommand` directly instead of a builder for that specific shell command. We want all shell commands executed using a builder for that specific shell command.

Builders:
- [X] `pacdiff`
- [x] `rm`
- [x] `paccache`

Operations that need `ShellCommand`'s replaced with builders:
- [x] clean
- [x] uninstall
- [x] upgrade