### PR TITLE
operations/clean: fix noconfirm for clean

### DIFF
--- a/src/builder/paccache.rs
+++ b/src/builder/paccache.rs
@@ -39,7 +39,7 @@ impl PaccacheBuilder {
         }
 
         command
-            .args(&["-r", &format!("-k{}", self.keep.to_string())])
+            .args(&["-r", &format!("-k{}", self.keep)])
             .wait_success()
             .await
     }

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -57,7 +57,7 @@ pub async fn clean(options: Options) {
             .uninstall()
             .await;
 
-        if let Err(_) = result {
+        if result.is_err() {
             crash!(AppExitCode::PacmanError, "Failed to remove orphans");
         } else {
             tracing::info!("Successfully removed orphans");

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -32,7 +32,7 @@ pub async fn clean(options: Options) {
             "Removing orphans would uninstall the following packages: \n{}",
             &orphaned_packages.stdout.trim_end()
         );
-        let cont = prompt!(default no, "Continue?");
+        let cont = noconfirm || prompt!(default no, "Continue?");
         if !cont {
             // If user doesn't want to continue, break
             tracing::info!("Exiting");
@@ -65,7 +65,9 @@ pub async fn clean(options: Options) {
     }
 
     // Prompt the user whether to clear the Amethyst cache
-    let clear_ame_cache = prompt!(default no, "Clear Amethyst's internal PKGBUILD cache?");
+    let clear_ame_cache =
+        noconfirm || prompt!(default no, "Clear Amethyst's internal PKGBUILD cache?");
+
     if clear_ame_cache {
         let cache_dir = get_cache_dir();
         RmBuilder::default()
@@ -78,11 +80,7 @@ pub async fn clean(options: Options) {
     }
 
     // Prompt the user whether to clear cache or not
-    let clear_pacman_cache = if noconfirm {
-        true
-    } else {
-        prompt!(default no, "Also clear pacman's package cache?")
-    };
+    let clear_pacman_cache = noconfirm || prompt!(default no, "Also clear pacman's package cache?");
 
     if clear_pacman_cache {
         let conf = Config::read();

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -33,7 +33,7 @@ async fn upgrade_repo(options: Options) {
         .upgrade()
         .await;
 
-    if let Err(_) = result {
+    if result.is_err() {
         let continue_upgrading = prompt!(default no,
             "Failed to upgrade repo packages, continue to upgrading AUR packages?",
         );


### PR DESCRIPTION
`clear_ame_cache` prompted when `--noconfirm` was active. This PR fixes that.