### PR TITLE
Add quiet support to more operations

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -24,8 +24,13 @@ pub struct Args {
     #[clap(long = "noconfirm", global = true)]
     pub no_confirm: bool,
 
-    /// Make some commands have less output
+    /// Make some commands have less output (only clean, upgrade, and install are supported)
     #[clap(long, short, global = true)]
+    // not gonna lie the only reason this option is here is because
+    // i was trying to figure out if paccache had a --noconfirm option.
+    // so basically, it doesn't, but hey, we might as well have it here
+    // anyways as some pacman commands can have a --quiet flag passed
+    // to them.
     pub quiet: bool,
 
     /// Loops sudo in the background to ensure it doesn't time out during long builds

--- a/src/builder/pacman.rs
+++ b/src/builder/pacman.rs
@@ -268,11 +268,18 @@ impl PacmanSearchBuilder {
 #[derive(Default, Debug, Clone)]
 pub struct PacmanUpgradeBuilder {
     no_confirm: bool,
+    quiet: bool,
 }
 
 impl PacmanUpgradeBuilder {
     pub fn no_confirm(mut self, no_confirm: bool) -> Self {
         self.no_confirm = no_confirm;
+
+        self
+    }
+
+    pub fn quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
 
         self
     }
@@ -283,6 +290,10 @@ impl PacmanUpgradeBuilder {
 
         if self.no_confirm {
             command = command.arg("--noconfirm")
+        }
+
+        if self.quiet {
+            command = command.arg("--quiet")
         }
 
         command.wait_success().await

--- a/src/builder/pacman.rs
+++ b/src/builder/pacman.rs
@@ -13,6 +13,7 @@ pub struct PacmanInstallBuilder {
     files: Vec<PathBuf>,
     as_deps: bool,
     no_confirm: bool,
+    quiet: bool,
     needed: bool,
 }
 
@@ -21,6 +22,7 @@ impl PacmanInstallBuilder {
         Self::default()
             .as_deps(options.asdeps)
             .no_confirm(options.noconfirm)
+            .quiet(options.quiet)
     }
 
     pub fn packages<I: IntoIterator<Item = S>, S: ToString>(mut self, packages: I) -> Self {
@@ -39,6 +41,12 @@ impl PacmanInstallBuilder {
 
     pub fn no_confirm(mut self, no_confirm: bool) -> Self {
         self.no_confirm = no_confirm;
+
+        self
+    }
+
+    pub fn quiet(mut self, quiet: bool) -> Self {
+        self.quiet = quiet;
 
         self
     }
@@ -68,6 +76,10 @@ impl PacmanInstallBuilder {
 
         if self.no_confirm {
             command = command.arg("--noconfirm")
+        }
+
+        if self.quiet {
+            command = command.arg("--quiet")
         }
 
         if self.as_deps {

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -25,11 +25,13 @@ pub async fn upgrade(args: UpgradeArgs, options: Options) {
 #[tracing::instrument(level = "trace")]
 async fn upgrade_repo(options: Options) {
     let noconfirm = options.noconfirm;
+    let quiet = options.quiet;
 
     tracing::debug!("Upgrading repo packages");
 
     let result = PacmanUpgradeBuilder::default()
         .no_confirm(noconfirm)
+        .quiet(quiet)
         .upgrade()
         .await;
 


### PR DESCRIPTION
some pacman commands can have a `--quiet` flag passed to them. this pr adds the code to be able to pass it to them.