### PR TITLE
Fixed env for flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,9 @@
           ];
           # For rust-analyzer
           RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+
+          # Amethyst codename
+          AMETHYST_CODENAME = "Nixilicious";
         };
 
         formatter = pkgs.alejandra;


### PR DESCRIPTION
Fixes the AMEHTYST_CODENAME envvar to be populated when working in a Nix Flake environment