### PR TITLE
operations/clean: make sure paccache keeps 3 pkgs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "Amethyst"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "alpm",
  "alpm-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Amethyst"
-version = "4.0.0"
+version = "4.1.0"
 authors = ["Michal S. <michal@tar.black>", "axtlos <axtlos@tar.black>", "trivernis <trivernis@protonmail.com>", "Fries <fries@tar.black>"]
 description = "A fast and efficient AUR helper"
 repository = "https://github.com/crystal-linux/amethyst"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "Amethyst"
 version = "4.0.0"
-authors = ["Michal S. <michal@tar.black>", "axtlos <axtlos@tar.black>", "trivernis <trivernis@protonmail.com>"]
+authors = ["Michal S. <michal@tar.black>", "axtlos <axtlos@tar.black>", "trivernis <trivernis@protonmail.com>", "Fries <fries@tar.black>"]
 description = "A fast and efficient AUR helper"
 repository = "https://github.com/crystal-linux/amethyst"
 license-file = "LICENSE"

--- a/src/internal/config.rs
+++ b/src/internal/config.rs
@@ -17,8 +17,6 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ConfigBase {
     pub pacdiff_warn: bool,
-    pub paccache_keep: i32,
-    pub paccache_keep_ins_pkgs: bool,
     pub aur_verification_prompt: bool,
 }
 
@@ -37,8 +35,6 @@ impl Default for ConfigBase {
     fn default() -> Self {
         Self {
             pacdiff_warn: true,
-            paccache_keep: 0,
-            paccache_keep_ins_pkgs: true,
             aur_verification_prompt: true,
         }
     }

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -83,14 +83,12 @@ pub async fn clean(options: Options) {
     let clear_pacman_cache = noconfirm || prompt!(default no, "Also clear pacman's package cache?");
 
     if clear_pacman_cache {
-        let conf = Config::read();
-
         // Clear pacman's cache
-        // keeps 0 versions of the package in the cache by default
-        // keeps installed packages in the cache by default
+        // keeps 3 versions of the package in the cache
+        // keeps installed packages in the cache
         let result = PaccacheBuilder::default()
-            .set_keep(conf.base.paccache_keep)
-            .keep_ins_pkgs(conf.base.paccache_keep_ins_pkgs)
+            .set_keep(3)
+            .keep_ins_pkgs(true)
             .quiet_output(quiet)
             .remove()
             .await;

--- a/src/operations/clean.rs
+++ b/src/operations/clean.rs
@@ -4,7 +4,6 @@ use crate::builder::pacman::PacmanUninstallBuilder;
 use crate::builder::rm::RmBuilder;
 use crate::crash;
 
-use crate::internal::config::Config;
 use crate::internal::exit_code::AppExitCode;
 
 use crate::internal::utils::get_cache_dir;


### PR DESCRIPTION
This PR changes paccache to keep 3 packages and to keep installed packages so `.pacnew` generation works properly.