### PR TITLE
operations/upgrade: stop if repo upgrade failed

### DIFF
--- a/i18n/de/Amethyst.ftl
+++ b/i18n/de/Amethyst.ftl
@@ -47,7 +47,7 @@ installed = installiert
 # operations::uninstall
 failed-remove-pkgs = Pakete konnten nicht deinstalliert werden
 # operations::upgrade
-failed-upgrade-repo-pkgs = Pakete von Paketquellen konnten nicht aktualisiert werden, fortfahren AUR Pakete zu aktualisieren?
+failed-upgrade-repo-pkgs = Pakete von Paketquellen konnten nicht aktualisiert werden
 success-upgrade-repo-pkgs = Pakete von Paketquellen wurden erfolgreich aktualisiert
 couldnt-find-remote-pkg = Remotepaket für {$pkg} konnte nicht gefunden werden
 no-upgrades-aur-package = Keine Aktualisierungen für AUR Pakete gefunden

--- a/i18n/en/Amethyst.ftl
+++ b/i18n/en/Amethyst.ftl
@@ -53,7 +53,7 @@ installed = installed
 failed-remove-pkgs = Failed to remove packages
 
 # operations::upgrade
-failed-upgrade-repo-pkgs = Failed to upgrade repo packages, continue to upgrading AUR packages?
+failed-upgrade-repo-pkgs = Failed to upgrade repo packages
 success-upgrade-repo-pkgs = Successfully upgraded repo packages
 couldnt-find-remote-pkg = Could not find the remote package for {$pkg}
 no-upgrades-aur-package = No upgrades available for installed AUR packages

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -36,13 +36,9 @@ async fn upgrade_repo(options: Options) {
         .await;
 
     if result.is_err() {
-        let continue_upgrading = prompt!(default no,
-            "{}", fl!("failed-upgrade-repo-pkgs")
-        );
-        if !continue_upgrading {
-            tracing::info!("Exiting");
-            std::process::exit(AppExitCode::PacmanError as i32);
-        }
+        tracing::error!("{}", fl!("failed-upgrade-repo-pkgs"));
+        tracing::info!("{}", fl!("exiting"));
+        std::process::exit(AppExitCode::PacmanError as i32);
     } else {
         tracing::info!("{}", fl!("success-upgrade-repo-pkgs"));
     }

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -5,7 +5,7 @@ use crate::internal::error::SilentUnwrap;
 use crate::internal::exit_code::AppExitCode;
 use crate::internal::rpc::rpcinfo;
 use crate::operations::aur_install::aur_install;
-use crate::{fl, prompt, Options};
+use crate::{fl, Options};
 
 /// Upgrades all installed packages
 #[tracing::instrument(level = "trace")]


### PR DESCRIPTION
This PR should stop upgrading from happening if the non AUR upgrades fail, as it might not be safe to do the AUR upgrades if they do.