### PR TITLE
query: add own switch

### DIFF
--- a/i18n/de/Amethyst.ftl
+++ b/i18n/de/Amethyst.ftl
@@ -98,7 +98,7 @@ installing-from-aur = Installiere {$amountOfPkgs} aus der AUR
 remove-installed-make-deps = Möchten Sie die ausschließlich zum Bauen verwendeten Abhängigkeiten entfernen?
 done = Fertig!
 # operations::aur_install
-aur-rpc-crash = AUR RPC Aufruf ist fehlgeschlagen:
+aur-rpc-crash = AUR RPC Aufruf ist fehlgeschlagen: {$error}
 failed-to-build = Konnte nicht gebaut werden
 makepkg-failed = makepkg ist fehlgeschlagen
 unknown-error = Unbekannter Fehler

--- a/i18n/en/Amethyst.ftl
+++ b/i18n/en/Amethyst.ftl
@@ -176,6 +176,7 @@ remove-packages = The name of the package(s) to remove
 query-aur = Lists AUR/foreign packages [-Qa, -Qm]
 query-repo = Lists repo/native packages [-Qr, -Qn]
 query-info = Get information about a specific package
+query-owns = Get information about which package owns a file
 upgrade-repo = Upgrades only repo/native packages
 upgrade-aur = Upgrades only from the AUR
 gencomp-shell = The shell to generate completions for (bash, fish, elvish, pwsh, fig)

--- a/i18n/en/Amethyst.ftl
+++ b/i18n/en/Amethyst.ftl
@@ -117,7 +117,7 @@ remove-installed-make-deps = Do you want to remove the installed make dependenci
 done = Done!
 
 # operations::aur_install
-aur-rpc-crash = AUR RPC Call failed with
+aur-rpc-crash = AUR RPC Call failed with: {$error}
 failed-to-build = Failed to build
 makepkg-failed = makepkg failed
 unknown-error = Unknown error
@@ -132,7 +132,7 @@ error-occurred = An error occurred
 
 # internal::detect
 sudo-prompt-failed = Sudo prompt failed
-scanning-pacnew-files = Scanning for pacnew files"
+scanning-pacnew-files = Scanning for pacnew files
 no-pacnew-found = No .pacnew files found
 pacnew-found = pacnew files found
 pacnew-warning =
@@ -142,7 +142,7 @@ pacnew-warning =
 run-pacdiff-now = Would you like to run pacdiff now?
 pacdiff-warning =
     Pacdiff uses vimdiff by default to edit files for merging. You can focus panes by mousing over them and pressing left click, and scroll up and down using your mouse's scroll wheel (or the arrow keys). To exit vimdiff, press the following key combination: ESC, :qa!, ENTER
-    You can surpress this warning in the future by setting `pacdiff_warn` to "false" in ~/.config/ame/config.toml
+    You can suppress this warning in the future by setting `pacdiff_warn` to "false" in ~/.config/ame/config.toml
 
 # internal::config
 config-docs = # See https://getcryst.al/docs/amethyst/config for more information on config keys

--- a/i18n/it/Amethyst.ftl
+++ b/i18n/it/Amethyst.ftl
@@ -115,7 +115,7 @@ remove-installed-make-deps = Rimuovere le dipendenze di compilazione?
 done = Fatto!
 
 # operations::aur_install
-aur-rpc-crash = La chiamata RCP a AUR non è riuscita:
+aur-rpc-crash = La chiamata RCP a AUR non è riuscita: {$error}
 failed-to-build = Errore di compilazione
 makepkg-failed = Errore di makepkg
 unknown-error = Errore sconosciuto

--- a/i18n/sv/Amethyst.ftl
+++ b/i18n/sv/Amethyst.ftl
@@ -115,7 +115,7 @@ remove-installed-make-deps = Vill du ta bort de installerade byggberoendena?
 done = Klart!
 
 # operations::aur_install
-aur-rpc-crash = AUR RPC-anrop misslyckades med
+aur-rpc-crash = AUR RPC-anrop misslyckades med: {$error}
 failed-to-build = Misslyckades att bygga
 makepkg-failed = makepkg misslyckades
 unknown-error = Okänt fel
@@ -130,7 +130,7 @@ error-occurred = Ett fel inträffade
 
 # internal::detect
 sudo-prompt-failed = Sudo prompt misslyckades
-scanning-pacnew-files = Letar efter nya pacnew filer"
+scanning-pacnew-files = Letar efter nya pacnew filer
 no-pacnew-found = Inga .pacnew filer hittades
 pacnew-found = pacnew filer hittades
 pacnew-warning =

--- a/src/args.rs
+++ b/src/args.rs
@@ -104,6 +104,9 @@ pub struct QueryArgs {
 
     #[arg(long, short, help = fl!("query-info"))]
     pub info: Option<String>,
+
+    #[arg(long, short, help = fl!("query-owns"))]
+    pub owns: Option<String>,
 }
 
 #[derive(Default, Debug, Clone, Parser)]

--- a/src/builder/pacman.rs
+++ b/src/builder/pacman.rs
@@ -111,6 +111,7 @@ enum PacmanQueryType {
     Info,
     Native,
     Orphaned,
+    Owns,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -154,6 +155,10 @@ impl PacmanQueryBuilder {
 
     pub fn orphaned() -> Self {
         Self::new(PacmanQueryType::Orphaned)
+    }
+
+    pub fn owns() -> Self {
+        Self::new(PacmanQueryType::Owns)
     }
 
     pub fn package(mut self, package: String) -> Self {
@@ -212,6 +217,7 @@ impl PacmanQueryBuilder {
             PacmanQueryType::Info => command.arg("-i"),
             PacmanQueryType::Native => command.arg("-n"),
             PacmanQueryType::Orphaned => command.arg("-dtq"),
+            PacmanQueryType::Owns => command.arg("-o"),
             PacmanQueryType::All => command,
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,7 @@ async fn cmd_search(args: InstallArgs, options: Options) {
 
 #[tracing::instrument(level = "trace")]
 async fn cmd_query(args: QueryArgs) {
-    let both = !args.aur && !args.repo && args.info.is_none();
+    let both = !args.aur && !args.repo && args.info.is_none() && args.owns.is_none();
 
     if args.repo {
         fl_info!("installed-repo-packages");
@@ -214,6 +214,16 @@ async fn cmd_query(args: QueryArgs) {
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
+    }
+
+    if let Some(owns) = args.owns {
+        let result = PacmanQueryBuilder::owns()
+            .package(owns.clone())
+            .query()
+            .await;
+        if result.is_err() {
+            fl_crash!(AppExitCode::PacmanError, "error-occurred");
+        }
     }
 }
 

--- a/src/operations/aur_install/mod.rs
+++ b/src/operations/aur_install/mod.rs
@@ -96,7 +96,11 @@ pub async fn aur_install(packages: Vec<String>, options: Options) {
     if let Err(e) = aur_install_internal(AurInstall::new(options, packages)).await {
         match e {
             AppError::Rpc(e) => {
-                crash!(AppExitCode::RpcError, "{} {e}", fl!("aur-rpc-crash"))
+                fl_crash!(
+                    AppExitCode::RpcError,
+                    "aur-rpc-crash",
+                    error = e.to_string()
+                )
             }
             AppError::BuildStepViolation => {
                 fl_crash!(AppExitCode::MakePkgError, "failed-to-build")


### PR DESCRIPTION
this pr adds an own switch that you can access with `-Qo` and it shows what package owns a file.