### PR TITLE
amethyst: upgrade clap and clap_complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,9 +278,9 @@ checksum = "8628d1f5b9a7b1196ce1aa660e3ba7e2559d350649cbe94993519c127df667f2"
 
 [[package]]
 name = "clap"
-version = "4.0.7"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1af219c3e254a8b4649d6ddaef886b2015089f35f2ac5e1db31410c0566ab8"
+checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
 dependencies = [
  "atty",
  "bitflags",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.0.7"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd114ae53ce5a0670f43d2f169c1cd26c69b4896b0c121900cf1e4d06d67316c"
+checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
 dependencies = [
  "heck",
  "proc-macro-error",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ alpm-utils = "2.0.0"
 pacmanconf = "2.0.0"
 chrono = { version = "0.4.22", default-features = false, features = [ "clock", "std", "wasmbind" ] }
 trigram = "0.4.4"
-clap = { version = "4.0.7", features = [ "derive", "wrap_help" ] }
+clap = { version = "4.0.9", features = [ "derive", "wrap_help" ] }
 regex = { version = "1.6.0", default-features = false, features = [ "std", "unicode-perl" ] }
 colored = "2.0.0"
 serde = { version = "1.0.144", default-features = false, features = [ "derive", "serde_derive" ] }
@@ -47,8 +47,8 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 textwrap = "0.15.0"
 crossterm = "0.25.0"
 toml = "0.5.9"
-clap_complete = "4.0.0-rc.1"
-clap_complete_fig = "4.0.0-rc.1"
+clap_complete = "4.0.2"
+clap_complete_fig = "4.0.0"
 color-eyre = { version = "0.6.2", features = ["issue-url", "url"] }
 indicatif = { version = "0.17.0", features = ["tokio"] }
 lazy_static = "1.4.0"


### PR DESCRIPTION
upgrades clap complete from rc versions to stable ones and bumps clap from 4.0.7 to 4.0.9