### PR TITLE
internal/detect: remove duplicate sudo prompt

### DIFF
--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -5,8 +5,6 @@ use crate::internal::config::Config;
 use crate::logging::get_logger;
 use crate::{fl, fl_prompt, fl_warn, prompt};
 
-use super::prompt_sudo_single;
-
 /// Searches the filesystem for .pacnew files and helps the user deal with them.
 #[tracing::instrument(level = "trace")]
 pub async fn detect() {

--- a/src/internal/detect.rs
+++ b/src/internal/detect.rs
@@ -10,9 +10,6 @@ use super::prompt_sudo_single;
 /// Searches the filesystem for .pacnew files and helps the user deal with them.
 #[tracing::instrument(level = "trace")]
 pub async fn detect() {
-    prompt_sudo_single()
-        .await
-        .expect(&fl!("sudo-prompt-failed"));
     let pb = get_logger().new_progress_spinner();
     pb.set_message(fl!("scanning-pacnew-files"));
 


### PR DESCRIPTION
removes a duplicate sudo prompt

fixes a bug with alternate sudo-likes, like `doas` which don't have a `-v` flag.