### PR TITLE
operations/upgrade: use vercmp to compare versions

### DIFF
--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -1,3 +1,5 @@
+use alpm::vercmp;
+
 use crate::args::UpgradeArgs;
 use crate::builder::pacman::{PacmanColor, PacmanQueryBuilder, PacmanUpgradeBuilder};
 use crate::internal::detect;
@@ -63,7 +65,7 @@ async fn upgrade_aur(options: Options) {
             .silent_unwrap(AppExitCode::RpcError);
 
         if let Some(remote_package) = remote_package {
-            if remote_package.metadata.version != pkg.version {
+            if vercmp(remote_package.metadata.version.clone(), pkg.version.clone()).is_ge() {
                 tracing::debug!(
                     "local version: {}, remote version: {}",
                     pkg.version,

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -65,7 +65,7 @@ async fn upgrade_aur(options: Options) {
             .silent_unwrap(AppExitCode::RpcError);
 
         if let Some(remote_package) = remote_package {
-            if vercmp(remote_package.metadata.version.clone(), pkg.version.clone()).is_ge() {
+            if vercmp(remote_package.metadata.version.clone(), pkg.version.clone()).is_gt() {
                 tracing::debug!(
                     "local version: {}, remote version: {}",
                     pkg.version,


### PR DESCRIPTION
this fixes a bug where git pkgs will upgrade everytime with the old logic so were using an alpm function that uses pacmans version compare logic

Fixes #93