### PR TITLE
Add checkupdates subcommand for `crystal-update` compat

### DIFF
--- a/i18n/en/Amethyst.ftl
+++ b/i18n/en/Amethyst.ftl
@@ -166,6 +166,7 @@ query = Queries installed packages
 upgrade = Upgrades locally installed packages to their latest versions (Default)
 gencomp = Generates shell completions for supported shells (bash, fish, elvish, pwsh)
 clean = Removes all orphaned packages
+checkupdates = Queries for and returns available package updates
 diff = Runs pacdiff
 install-packages = The name of the package(s) to install or search for
 install-aur = Operate only on AUR packages

--- a/src/args.rs
+++ b/src/args.rs
@@ -60,6 +60,9 @@ pub enum Operation {
     #[command(bin_name = "ame", name = "clean", short_flag = 'C', about = fl!("clean"))]
     Clean,
 
+    #[command(bin_name = "ame", name = "checkupdates", about = fl!("checkupdates"))]
+    CheckUpdates,
+
     #[command(bin_name = "ame", name = "diff", short_flag = 'd', about = fl!("diff"))]
     Diff,
 }

--- a/src/internal/commands.rs
+++ b/src/internal/commands.rs
@@ -69,6 +69,10 @@ impl ShellCommand {
         Self::new(pager)
     }
 
+    pub fn checkupdates() -> Self {
+        Self::new("checkupdates")
+    }
+
     fn new<S: ToString>(command: S) -> Self {
         Self {
             command: command.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ async fn main() {
             fl_info!("removing-orphans");
             operations::clean(options).await;
         }
+        Operation::CheckUpdates => cmd_checkupdates().await,
         Operation::GenComp(gen_args) => cmd_gencomp(&gen_args),
         Operation::Diff => detect().await,
     }
@@ -225,6 +226,19 @@ async fn cmd_query(args: QueryArgs) {
             fl_crash!(AppExitCode::PacmanError, "error-occurred");
         }
     }
+}
+
+#[tracing::instrument(level = "trace")]
+async fn cmd_checkupdates() {
+    // TODO: Implement AUR update checking, which would then respectively display in crystal-update
+    println!(
+        "{}",
+        ShellCommand::checkupdates()
+            .wait_with_output()
+            .await
+            .silent_unwrap(AppExitCode::Other)
+            .stdout
+    );
 }
 
 #[tracing::instrument(level = "trace")]


### PR DESCRIPTION
I believe this PR should be squashed and backported to `patches/v4.0.0` for a `v4.0.4` release, as we need it for `crystal-update`, even if it breaks semver a little.