### PR TITLE
Add an explicit (-e) option to the query command.

### DIFF
--- a/i18n/de/Amethyst.ftl
+++ b/i18n/de/Amethyst.ftl
@@ -154,6 +154,7 @@ install-by = Sucht nach dem Wert eines bestimmten Feldes
 remove-packages = Die Namen der Pakete, die entfernt werden sollen
 query-aur = Listet AUR und Pacman-fremde Pakete auf [-Qa, -Qm]
 query-repo = Listet Pakete aus den Pacman-Paketquellen auf [-Qr, -Qn]
+query-explicit = Listet Pakete auf, die explizit installiert wurden [-Qe]
 query-info = Gibt Informationen über ein bestimmtes Paket aus
 upgrade-repo = Aktualisiert nur Pakete aus Pacman-Paketquellen
 upgrade-aur = Aktualisiert nur AUR-Pakete

--- a/i18n/en/Amethyst.ftl
+++ b/i18n/en/Amethyst.ftl
@@ -175,6 +175,7 @@ install-by = Searches by a specific field
 remove-packages = The name of the package(s) to remove
 query-aur = Lists AUR/foreign packages [-Qa, -Qm]
 query-repo = Lists repo/native packages [-Qr, -Qn]
+query-explicit = Lists explicitly installed packages [-Qe]
 query-info = Get information about a specific package
 query-owns = Get information about which package owns a file
 upgrade-repo = Upgrades only repo/native packages

--- a/src/args.rs
+++ b/src/args.rs
@@ -102,6 +102,9 @@ pub struct QueryArgs {
     #[arg(long, short, help = fl!("query-repo"))]
     pub repo: bool,
 
+    #[arg(long, short, help = fl!("query-explicit"))]
+    pub explicit: bool,
+
     #[arg(long, short, help = fl!("query-info"))]
     pub info: Option<String>,
 

--- a/src/builder/pacman.rs
+++ b/src/builder/pacman.rs
@@ -101,6 +101,7 @@ impl PacmanInstallBuilder {
 pub struct PacmanQueryBuilder {
     query_type: PacmanQueryType,
     color: PacmanColor,
+    explicit: bool,
     packages: Vec<String>,
 }
 
@@ -133,6 +134,7 @@ impl PacmanQueryBuilder {
         Self {
             query_type,
             color: PacmanColor::default(),
+            explicit: false,
             packages: Vec::new(),
         }
     }
@@ -177,6 +179,12 @@ impl PacmanQueryBuilder {
 
     pub fn color(mut self, color: PacmanColor) -> Self {
         self.color = color;
+
+        self
+    }
+
+    pub fn explicit(mut self, explicit: bool) -> Self {
+        self.explicit = explicit;
 
         self
     }
@@ -233,6 +241,10 @@ impl PacmanQueryBuilder {
             }
             PacmanColor::Never => command.arg("never"),
         };
+
+        if self.explicit {
+            command = command.arg("--explicit")
+        }
 
         command.args(self.packages)
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,21 +189,21 @@ async fn cmd_query(args: QueryArgs) {
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
-        }
-        
-        if args.aur {
-            fl_info!("installed-aur-packages");
-            PacmanQueryBuilder::foreign()
+    }
+
+    if args.aur {
+        fl_info!("installed-aur-packages");
+        PacmanQueryBuilder::foreign()
             .color(PacmanColor::Always)
             .explicit(args.explicit)
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
-        }
-        
-        if both {
-            fl_info!("installed-packages");
-            PacmanQueryBuilder::all()
+    }
+
+    if both {
+        fl_info!("installed-packages");
+        PacmanQueryBuilder::all()
             .color(PacmanColor::Always)
             .explicit(args.explicit)
             .query()

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,24 +185,27 @@ async fn cmd_query(args: QueryArgs) {
         fl_info!("installed-repo-packages");
         PacmanQueryBuilder::native()
             .color(PacmanColor::Always)
+            .explicit(args.explicit)
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
-    }
-
-    if args.aur {
-        fl_info!("installed-aur-packages");
-        PacmanQueryBuilder::foreign()
+        }
+        
+        if args.aur {
+            fl_info!("installed-aur-packages");
+            PacmanQueryBuilder::foreign()
             .color(PacmanColor::Always)
+            .explicit(args.explicit)
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
-    }
-
-    if both {
-        fl_info!("installed-packages");
-        PacmanQueryBuilder::all()
+        }
+        
+        if both {
+            fl_info!("installed-packages");
+            PacmanQueryBuilder::all()
             .color(PacmanColor::Always)
+            .explicit(args.explicit)
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);
@@ -211,6 +214,7 @@ async fn cmd_query(args: QueryArgs) {
     if let Some(info) = args.info {
         PacmanQueryBuilder::info()
             .package(info)
+            .explicit(args.explicit)
             .query()
             .await
             .silent_unwrap(AppExitCode::PacmanError);


### PR DESCRIPTION
I was missing this option and thought I would implement it myself :smile_cat:


This new query-option can be used in combination with the  --aur, --repo,
--info option or without any more options.

It is used to display explicitly installed packages
and corresponds to the `pacman --Qe` command.

Furthermore, I added a German translation for the new query-option

Anyway, see you on Discord :heart: :rainbow: 